### PR TITLE
Added support for SNAP_BUILD_PROXY

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ usually suffice.
 
 Take a look in the example directory to see the source snippet above
 in context.
+
+Flags and Other Notes
+---------------------
+
+If you are in a network restricted environment, and need to go through
+a proxy to build a snap, set SNAP_BUILD_PROXY in your terminal
+environment. This will set HTTP/S_PROXY for just the snap build, which
+is useful, as simply setting HTTP_PROXY may interfere with some of the
+snap tests.

--- a/snapstack/plan.py
+++ b/snapstack/plan.py
@@ -4,6 +4,7 @@ for a snap inside of a temporary Openstack environment.
 
 '''
 
+import os
 import subprocess
 import tempfile
 
@@ -42,6 +43,8 @@ class Plan:
         self._tests = tests or []
         self._test_cleanup = test_cleanup or []
 
+        self._snap_build_proxy = os.environ.get('SNAP_BUILD_PROXY')
+
     def run(self, cleanup=True):
         '''
         Execute all of our steps. Cleanup may be skipped.
@@ -49,7 +52,10 @@ class Plan:
         '''
         try:
             for step in self._base_setup + self._tests:
-                step.run(tempdir=self._tempdir)
+                step.run(
+                    tempdir=self._tempdir,
+                    snap_build_proxy=self._snap_build_proxy
+                )
         finally:
             if not cleanup:
                 return


### PR DESCRIPTION
Allows us to set HTTP_PROXY for just the snap build steps, which makes
things work in a bastion.

@ryan-beisner @coreycb @javacruft 