### PR TITLE
The gate was still failing.

### DIFF
--- a/snapstack/scripts/packages.sh
+++ b/snapstack/scripts/packages.sh
@@ -5,9 +5,18 @@
 
 # TODO: make this cross distro friendly
 
-set -ex
+# Update apt. Skip setting -ex if we're allowing unsigned repositories
+# (as we do in the openstack gate) until after we've apt updated, as
+# it will always return an error when there are unsigned packages,
+# even if we pass --allow-unauthenciated.
+if [ ${ALLOW_UNAUTHENTICATED+x} ]; then
+    sudo apt update $ALLOW_UNAUTHENTICATED
+    set -ex
+else
+    set -ex
+    sudo apt update
+fi
 
-sudo apt update $ALLOW_UNAUTHENTICATED
 DEBIAN_FRONTEND='noninteractive' sudo -E apt install $ALLOW_UNAUTHENTICATED --yes python3-openstackclient rabbitmq-server mysql-server \
     memcached libvirt-bin qemu-kvm apparmor-utils python-neutronclient openvswitch-switch
 


### PR DESCRIPTION
Apparently, sudo apt-update still returns an error exit code when you
have an unsigned repo, even if you pass --allow-unauthenticated.

Tweaked packages.sh so that it doesn't exit in this case.