### PR TITLE
SNAP_BUILD_PROXY now works for http and https.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,9 @@ Flags and Other Notes
 If you are in a network restricted environment, and need to go through
 a proxy to build a snap, set SNAP_BUILD_PROXY in your terminal
 environment. This will set HTTP/S_PROXY for just the snap build, which
-is useful, as simply setting HTTP_PROXY may interfere with some of the
-snap tests.
+is useful, as simply setting HTTP_PROXY and HTTPS_PROXY may interfere
+with some of the snap tests.
+
+Note that you may use one string for both http and https proxy, and
+you may omit the protocol (http/s://) part of the url; snapstack will
+fix the url up before using it.

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -5,7 +5,7 @@ import unittest
 from snapstack import Plan, Step
 
 
-class TestRunner(unittest.TestCase):
+class TestPlan(unittest.TestCase):
 
     @mock.patch('snapstack.plan.subprocess')
     @mock.patch('snapstack.step.subprocess')

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1,0 +1,16 @@
+import unittest
+
+from snapstack.step import fix_proxy_string
+
+
+class TestStep(unittest.TestCase):
+
+    def test_proxy_string(self):
+        fps = fix_proxy_string
+
+        self.assertEqual(fps('https://foo.bar'), 'http://foo.bar')
+        self.assertEqual(fps('https://foo.bar', https=True), 'https://foo.bar')
+        self.assertEqual(fps('http://foo.bar', https=True), 'https://foo.bar')
+        self.assertEqual(fps('http://foo.bar'), 'http://foo.bar')
+        self.assertEqual(fps('foo.bar', https=True), 'https://foo.bar')
+        self.assertEqual(fps('foo.bar'), 'http://foo.bar')


### PR DESCRIPTION
https was broken before. We now manipulate the string when setting
HTTP and HTTPS_PROXY so that it uses the correct protocol.

@coreycb 