### PR TITLE
Moved refs to scripts out of snap-test.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,27 @@ from setuptools import setup, find_packages
 this_dir = os.path.abspath(os.path.dirname(__file__))
 reqs_file = os.path.join(this_dir, 'requirements.txt')
 scripts = glob('snapstack/scripts/*.sh') + glob('snapstack/scripts/*.py')
+scripts += ['snapstack/scripts/admin-openrc']
+
+
+def config_files():
+    '''
+    Grab all the snap configuration files we've stuffed in etc.
+
+    '''
+    file_list = []
+    for dir_, _, files in os.walk('snapstack/scripts/etc'):
+        if not files:
+            continue
+        file_list += [os.sep.join([dir_, file_])[10:] for file_ in files]
+
+    return file_list
 
 
 with open(reqs_file) as f:
     reqs = [line for line in f.read().splitlines()
             if not line.startswith('--')]
+
 
 SETUP = {
     'name': "snapstack",
@@ -23,6 +39,7 @@ SETUP = {
     'long_description': open('README.md').read(),
     'install_requires': reqs,
     'scripts': scripts,
+    'package_data': {'snapstack': config_files()}
 }
 
 if __name__ == '__main__':

--- a/snap-deploy
+++ b/snap-deploy
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# snap-deploy
+#
+# Utility script that installs snapstack in a virtualenv, then deploys
+# a basic version of Openstack using snaps. To use it, source the
+# admin-openrc in snapstack/scripts, and execute openstack commands as
+# you normally would.
+#
+# To uninstall, run snap-destroy.
+
+
+tox --notest -e full
+
+source .tox/full/bin/activate
+
+python3 -c "from snapstack import Plan; Plan().deploy()"

--- a/snap-destroy
+++ b/snap-destroy
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# snap-destroy
+#
+# Utility script that removes an openstack created by snap-deploy.
+
+
+tox --notest -e full
+
+source .tox/full/bin/activate
+
+python3 -c "from snapstack import Plan; Plan().destroy()"

--- a/snapstack/base.py
+++ b/snapstack/base.py
@@ -42,7 +42,7 @@ class Setup(Base):
     def __init__(self):
         super(Setup, self).__init__()
         self._steps['confs'] = Step(
-            script_loc='{snap-test}',
+            script_loc='{snapstack}',
             files=CONF_FILES
         )
         self._steps['packages'] = Step(
@@ -50,37 +50,37 @@ class Setup(Base):
             scripts=['packages.sh']
         )
         self._steps['rabbit_and_db'] = Step(
-            script_loc='{snap-test}',
-            scripts=['scripts/rabbitmq.sh', 'scripts/database.sh']
+            script_loc='{snapstack}',
+            scripts=['rabbitmq.sh', 'database.sh']
         )
         self._steps['keystone'] = Step(
             snap='keystone',
-            script_loc='{snap-test}',
-            scripts=['scripts/keystone.sh']
+            script_loc='{openstack}/snap-{snap}/master/',
+            scripts=['tests/keystone.sh']
         )
         self._steps['nova'] = Step(
             snap='nova',
-            script_loc='{snap-test}',
-            scripts=['scripts/nova.sh']
+            script_loc='{openstack}/snap-{snap}/master/',
+            scripts=['tests/nova.sh']
         )
         self._steps['neutron'] = Step(
             snap='neutron',
-            script_loc='{snap-test}',
-            scripts=['scripts/neutron.sh'],
+            script_loc='{openstack}/snap-{snap}/master/',
+            scripts=['tests/neutron.sh'],
         )
         self._steps['glance'] = Step(
             snap='glance',
-            script_loc='{snap-test}',
-            scripts=['scripts/glance.sh']
+            script_loc='{openstack}/snap-{snap}/master/',
+            scripts=['tests/glance.sh']
         )
         self._steps['nova_hypervisor'] = Step(
             snap='nova-hypervisor',
-            script_loc='{snap-test}',
-            scripts=['scripts/nova-hypervisor.sh']
+            script_loc='{openstack}/snap-{snap}/master/',
+            scripts=['tests/nova-hypervisor.sh']
         )
         self._steps['neutron_ext_net'] = Step(
-            script_loc='{snap-test}',
-            scripts=['scripts/neutron-ext-net.sh']
+            script_loc='{snapstack}',
+            scripts=['neutron-ext-net.sh']
         )
 
 

--- a/snapstack/config.py
+++ b/snapstack/config.py
@@ -1,3 +1,5 @@
+import os
+
 '''
 Default config values for snapstack live here.
 
@@ -28,10 +30,9 @@ CONF_FILES = [
 
 
 LOCATION_VARS = {
-    'snapstack': '',  # Snapstack adds some scripts to your PATH.
-    'snap-test': (
-        'https://raw.githubusercontent.com/openstack-snaps/snap-test/master/'
-    ),
+    'snapstack': '{snapstack}/scripts/'.format(
+        snapstack=os.path.dirname(__file__)),
+    'openstack': 'https://raw.githubusercontent.com/openstack',
     'snap': None  # Filled in by _run
 }
 

--- a/snapstack/plan.py
+++ b/snapstack/plan.py
@@ -58,16 +58,14 @@ class Plan:
                     http_proxy=self._http_proxy,
                     https_proxy=self._https_proxy)
         finally:
-            if not cleanup:
-                return
+            if cleanup:
+                for step in self._base_setup + self._tests:
+                    if not step.snap:
+                        continue
+                    subprocess.run(['sudo', 'snap', 'remove', step.snap])
 
-            for step in self._base_setup + self._tests:
-                if not step.snap:
-                    continue
-                subprocess.run(['sudo', 'snap', 'remove', step.snap])
+                for step in self._test_cleanup:
+                    step.run(tempdir=self._tempdir)
 
-            for step in self._test_cleanup:
-                step.run(tempdir=self._tempdir)
-
-            for step in self._base_cleanup:
-                step.run(tempdir=self._tempdir)
+                for step in self._base_cleanup:
+                    step.run(tempdir=self._tempdir)

--- a/snapstack/scripts/admin-openrc
+++ b/snapstack/scripts/admin-openrc
@@ -1,0 +1,8 @@
+export OS_PROJECT_DOMAIN_NAME=default
+export OS_USER_DOMAIN_NAME=default
+export OS_PROJECT_NAME=admin
+export OS_USERNAME=admin
+export OS_PASSWORD=keystone
+export OS_AUTH_URL=http://localhost:35357
+export OS_IDENTITY_API_VERSION=3
+export OS_IMAGE_API_VERSION=2

--- a/snapstack/scripts/database.sh
+++ b/snapstack/scripts/database.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -ex
+
+sudo mysql -u root << EOF
+CREATE DATABASE IF NOT EXISTS keystone;
+GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'localhost' \
+  IDENTIFIED BY 'keystone';
+CREATE DATABASE IF NOT EXISTS nova;
+CREATE DATABASE IF NOT EXISTS nova_api;
+CREATE DATABASE IF NOT EXISTS nova_cell0;
+GRANT ALL PRIVILEGES ON nova.* TO 'nova'@'localhost' \
+  IDENTIFIED BY 'nova';
+GRANT ALL PRIVILEGES ON nova_api.* TO 'nova'@'localhost' \
+  IDENTIFIED BY 'nova';
+GRANT ALL PRIVILEGES ON nova_cell0.* TO 'nova'@'localhost' \
+  IDENTIFIED BY 'nova';
+CREATE DATABASE IF NOT EXISTS neutron;
+GRANT ALL PRIVILEGES ON neutron.* TO 'neutron'@'localhost' \
+  IDENTIFIED BY 'neutron';
+CREATE DATABASE IF NOT EXISTS glance;
+GRANT ALL PRIVILEGES ON glance.* TO 'glance'@'localhost' \
+  IDENTIFIED BY 'glance';
+CREATE DATABASE IF NOT EXISTS cinder;
+GRANT ALL PRIVILEGES ON cinder.* TO 'cinder'@'localhost' \
+  IDENTIFIED BY 'cinder';
+EOF

--- a/snapstack/scripts/etc/snap-cinder/cinder/cinder/cinder.conf.d/database.conf
+++ b/snapstack/scripts/etc/snap-cinder/cinder/cinder/cinder.conf.d/database.conf
@@ -1,0 +1,2 @@
+[database]
+connection = mysql+pymysql://cinder:cinder@localhost/cinder

--- a/snapstack/scripts/etc/snap-cinder/cinder/cinder/cinder.conf.d/keystone.conf
+++ b/snapstack/scripts/etc/snap-cinder/cinder/cinder/cinder.conf.d/keystone.conf
@@ -1,0 +1,13 @@
+[DEFAULT]
+auth_strategy = keystone
+
+[keystone_authtoken]
+auth_uri = http://localhost:5000
+auth_url = http://localhost:35357
+memcached_servers = localhost:11211
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+project_name = service
+username = cinder
+password = cinder

--- a/snapstack/scripts/etc/snap-cinder/cinder/cinder/cinder.conf.d/lvm.conf
+++ b/snapstack/scripts/etc/snap-cinder/cinder/cinder/cinder.conf.d/lvm.conf
@@ -1,0 +1,11 @@
+[DEFAULT]
+enabled_backends = lvm
+
+[lvm]
+volume_group = cinder-volumes
+volume_driver = cinder.volume.drivers.lvm.LVMVolumeDriver
+volume_name_template = volume-%s
+volume_backend_name = lvm
+volumes_dir = /var/snap/cinder/common/lib/volumes
+iscsi_protocol = iscsi
+iscsi_helper = tgtadm

--- a/snapstack/scripts/etc/snap-cinder/cinder/cinder/cinder.conf.d/rabbitmq.conf
+++ b/snapstack/scripts/etc/snap-cinder/cinder/cinder/cinder.conf.d/rabbitmq.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+transport_url = rabbit://openstack:rabbitmq@localhost

--- a/snapstack/scripts/etc/snap-cinder/tgt/conf.d/cinder_tgt.conf
+++ b/snapstack/scripts/etc/snap-cinder/tgt/conf.d/cinder_tgt.conf
@@ -1,0 +1,1 @@
+include /var/snap/cinder/common/lib/volumes/*

--- a/snapstack/scripts/etc/snap-glance/glance/glance.conf.d/database.conf
+++ b/snapstack/scripts/etc/snap-glance/glance/glance.conf.d/database.conf
@@ -1,0 +1,2 @@
+[database]
+connection = mysql+pymysql://glance:glance@localhost/glance

--- a/snapstack/scripts/etc/snap-glance/glance/glance.conf.d/keystone.conf
+++ b/snapstack/scripts/etc/snap-glance/glance/glance.conf.d/keystone.conf
@@ -1,0 +1,13 @@
+[keystone_authtoken]
+auth_uri = http://localhost:5000
+auth_url = http://localhost:35357
+memcached_servers = localhost:11211
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+project_name = service
+username = glance
+password = glance
+
+[paste_deploy]
+flavor = keystone

--- a/snapstack/scripts/etc/snap-keystone/keystone/keystone.conf.d/database.conf
+++ b/snapstack/scripts/etc/snap-keystone/keystone/keystone.conf.d/database.conf
@@ -1,0 +1,2 @@
+[database]
+connection = mysql+pymysql://keystone:keystone@localhost/keystone

--- a/snapstack/scripts/etc/snap-neutron/neutron/neutron.conf.d/database.conf
+++ b/snapstack/scripts/etc/snap-neutron/neutron/neutron.conf.d/database.conf
@@ -1,0 +1,2 @@
+[database]
+connection = mysql+pymysql://neutron:neutron@localhost/neutron

--- a/snapstack/scripts/etc/snap-neutron/neutron/neutron.conf.d/keystone.conf
+++ b/snapstack/scripts/etc/snap-neutron/neutron/neutron.conf.d/keystone.conf
@@ -1,0 +1,13 @@
+[DEFAULT]
+auth_strategy = keystone
+
+[keystone_authtoken]
+auth_uri = http://localhost:5000
+auth_url = http://localhost:35357
+memcached_servers = localhost:11211
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+project_name = service
+username = neutron
+password = neutron

--- a/snapstack/scripts/etc/snap-neutron/neutron/neutron.conf.d/nova.conf
+++ b/snapstack/scripts/etc/snap-neutron/neutron/neutron.conf.d/nova.conf
@@ -1,0 +1,13 @@
+[DEFAULT]
+notify_nova_on_port_status_changes = True
+notify_nova_on_port_data_changes = True
+
+[nova]
+auth_url = http://localhost:35357
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+region_name = RegionOne
+project_name = service
+username = nova
+password = nova

--- a/snapstack/scripts/etc/snap-nova-hypervisor/neutron/metadata_agent.ini
+++ b/snapstack/scripts/etc/snap-nova-hypervisor/neutron/metadata_agent.ini
@@ -1,0 +1,3 @@
+[DEFAULT]
+nova_metadata_ip = localhost
+metadata_proxy_shared_secret = supersecret

--- a/snapstack/scripts/etc/snap-nova-hypervisor/neutron/plugins/ml2/openvswitch_agent.ini
+++ b/snapstack/scripts/etc/snap-nova-hypervisor/neutron/plugins/ml2/openvswitch_agent.ini
@@ -1,0 +1,10 @@
+[securitygroup]
+enable_security_group = True
+firewall_driver = iptables_hybrid
+
+[AGENT]
+tunnel_types = geneve,vxlan,gre
+
+[ovs]
+local_ip = 127.0.0.1
+bridge_mappings = physnet1:br-ex

--- a/snapstack/scripts/etc/snap-nova-hypervisor/nova/nova.conf.d/glance.conf
+++ b/snapstack/scripts/etc/snap-nova-hypervisor/nova/nova.conf.d/glance.conf
@@ -1,0 +1,2 @@
+[glance]
+api_servers = http://localhost:9292

--- a/snapstack/scripts/etc/snap-nova-hypervisor/nova/nova.conf.d/keystone.conf
+++ b/snapstack/scripts/etc/snap-nova-hypervisor/nova/nova.conf.d/keystone.conf
@@ -1,0 +1,13 @@
+[DEFAULT]
+auth_strategy = keystone
+
+[keystone_authtoken]
+auth_uri = http://localhost:5000
+auth_url = http://localhost:35357
+memcached_servers = localhost:11211
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+project_name = service
+username = nova
+password = nova

--- a/snapstack/scripts/etc/snap-nova-hypervisor/nova/nova.conf.d/neutron.conf
+++ b/snapstack/scripts/etc/snap-nova-hypervisor/nova/nova.conf.d/neutron.conf
@@ -1,0 +1,17 @@
+[DEFAULT]
+use_neutron = True
+firewall_driver = nova.virt.firewall.NoopFirewallDriver
+
+[neutron]
+url = http://localhost:9696
+auth_url = http://localhost:35357
+memcached_servers = localhost:11211
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+region_name = RegionOne
+project_name = service
+username = neutron
+password = neutron
+service_metadata_proxy = True
+metadata_proxy_shared_secret = supersecret

--- a/snapstack/scripts/etc/snap-nova-hypervisor/nova/nova.conf.d/nova-placement.conf
+++ b/snapstack/scripts/etc/snap-nova-hypervisor/nova/nova.conf.d/nova-placement.conf
@@ -1,0 +1,9 @@
+[placement]
+os_region_name = RegionOne
+project_domain_name = default
+project_name = service
+auth_type = password
+user_domain_name = default
+auth_url = http://localhost:35357
+username = placement
+password = placement

--- a/snapstack/scripts/etc/snap-nova-hypervisor/nova/nova.conf.d/rabbitmq.conf
+++ b/snapstack/scripts/etc/snap-nova-hypervisor/nova/nova.conf.d/rabbitmq.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+transport_url = rabbit://openstack:rabbitmq@localhost

--- a/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/database.conf
+++ b/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/database.conf
@@ -1,0 +1,5 @@
+[database]
+connection = mysql+pymysql://nova:nova@localhost/nova
+
+[api_database]
+connection = mysql+pymysql://nova:nova@localhost/nova_api

--- a/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/glance.conf
+++ b/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/glance.conf
@@ -1,0 +1,2 @@
+[glance]
+api_servers = http://localhost:9292

--- a/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/keystone.conf
+++ b/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/keystone.conf
@@ -1,0 +1,13 @@
+[keystone_authtoken]
+auth_uri = http://localhost:5000
+auth_url = http://localhost:35357
+memcached_servers = localhost:11211
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+project_name = service
+username = nova
+password = nova
+
+[paste_deploy]
+flavor = keystone

--- a/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/neutron.conf
+++ b/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/neutron.conf
@@ -1,0 +1,15 @@
+[DEFAULT]
+use_neutron = True
+firewall_driver = nova.virt.firewall.NoopFirewallDriver
+
+[neutron]
+url = http://localhost:9696
+auth_url = http://localhost:35357
+memcached_servers = localhost:11211
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+region_name = RegionOne
+project_name = service
+username = neutron
+password = neutron

--- a/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/nova-placement.conf
+++ b/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/nova-placement.conf
@@ -1,0 +1,9 @@
+[placement]
+os_region_name = RegionOne
+project_domain_name = default
+project_name = service
+auth_type = password
+user_domain_name = default
+auth_url = http://localhost:35357
+username = placement
+password = placement

--- a/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/rabbitmq.conf
+++ b/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/rabbitmq.conf
@@ -1,0 +1,2 @@
+[DEFAULT]
+transport_url = rabbit://openstack:rabbitmq@localhost

--- a/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/scheduler.conf
+++ b/snapstack/scripts/etc/snap-nova/nova/nova.conf.d/scheduler.conf
@@ -1,0 +1,3 @@
+[scheduler]
+discover_hosts_in_cells_interval = 30
+scheduler_driver = filter_scheduler

--- a/snapstack/scripts/neutron-ext-net.sh
+++ b/snapstack/scripts/neutron-ext-net.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -ex
+
+source $BASE_DIR/admin-openrc
+
+sudo ovs-vsctl --may-exist add-br br-ex
+
+# Create bridge for local access to instances
+sudo brctl addbr br-dw || :
+sudo ip addr flush br-dw
+sudo ip addr add 10.30.20.1/24 dev br-dw
+sudo ip link set br-dw up
+
+# Wire linux bridge to ovs bridge
+sudo ip link add dodgy-wiring0 type veth peer name dodgy-wiring1 || :
+sudo brctl addif br-dw dodgy-wiring1 || :
+sudo ovs-vsctl --may-exist add-port br-ex dodgy-wiring0
+
+sudo ip link set dodgy-wiring1 up
+sudo ip link set dodgy-wiring0 up
+
+neutron net-show ext_net || {
+    neutron net-create --provider:network_type=flat --provider:physical_network physnet1 \
+        --router:external ext_net
+    neutron subnet-create --gateway 10.30.20.1 \
+        --dns-nameserver 10.30.20.1 --disable-dhcp \
+        ext_net 10.30.20.0/24
+}
+
+neutron router-show provider-router || {
+    neutron router-create provider-router
+    neutron router-gateway-set provider-router ext_net
+    neutron router-interface-add provider-router test_subnet
+}

--- a/snapstack/scripts/rabbitmq.sh
+++ b/snapstack/scripts/rabbitmq.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+sudo rabbitmqctl list_users | grep openstack || sudo rabbitmqctl add_user openstack rabbitmq
+sudo rabbitmqctl set_permissions openstack ".*" ".*" ".*"

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -41,11 +41,13 @@ class TestPlan(unittest.TestCase):
             os.path.exists(os.sep.join([plan.tempdir, 'admin-openrc'])))
 
         mock_subprocess.run.assert_called_with(
-            [os.sep.join([plan.tempdir, 'scripts/neutron-ext-net.sh'])],
+            [os.sep.join([plan.tempdir, 'neutron-ext-net.sh'])],
             env=env)
 
         plan.run()  # Run plan again with cleanup
-        mock_subprocess.run.assert_called_with(['sql_cleanup.py'], env=env)
+        mock_subprocess.run.assert_called_with(
+            [os.sep.join([plan.tempdir, 'sql_cleanup.py'])],
+            env=env)
 
     @unittest.skipUnless(
         os.environ.get('SNAPSTACK_TEST_INSTALL'),


### PR DESCRIPTION
They now all live either inside of snapstack's scripts/ folder, or in
the repo for the snap that they set up.

This will help us deprecate snap-test, and centralize our testing
setup.