### PR TITLE
Add symlink to admin-openrc in root directory

### DIFF
--- a/admin-openrc
+++ b/admin-openrc
@@ -1,0 +1,1 @@
+snapstack/scripts/admin-openrc


### PR DESCRIPTION
This is useful when using snap-deploy and snap-destroy rather than
having to dig deeper in subdirectories to find the file.