### PR TITLE
Remove snaps after running cleanup scripts

### DIFF
--- a/snapstack/base.py
+++ b/snapstack/base.py
@@ -29,7 +29,7 @@ class Base:
 
     def remove_steps(self, *steps):
         '''
-        Each arg should be a stirng naming a step. We'll remove the named
+        Each arg should be a string naming a step. We'll remove the named
         step from our map of steps.
 
         '''
@@ -117,4 +117,24 @@ class Cleanup(Base):
         self._steps['snapstack_cleanup'] = Step(
             script_loc='{snapstack}',
             scripts=['cleanup.py']
+        )
+        self._steps['keystone'] = Step(
+            script_loc='{openstack}/snap-keystone/master/tests/',
+            scripts=['keystone_cleanup.sh'],
+        )
+        self._steps['nova'] = Step(
+            script_loc='{openstack}/snap-nova/master/tests/',
+            scripts=['nova_cleanup.sh'],
+        )
+        self._steps['neutron'] = Step(
+            script_loc='{openstack}/snap-neutron/master/tests/',
+            scripts=['neutron_cleanup.sh'],
+        )
+        self._steps['glance'] = Step(
+            script_loc='{openstack}/snap-glance/master/tests/',
+            scripts=['glance_cleanup.sh'],
+        )
+        self._steps['nova_hypervisor'] = Step(
+            script_loc='{openstack}/snap-nova-hypervisor/master/tests/',
+            scripts=['nova-hypervisor_cleanup.sh'],
         )

--- a/snapstack/plan.py
+++ b/snapstack/plan.py
@@ -59,21 +59,21 @@ class Plan:
 
     def destroy(self):
         '''
-        Remove any snaps that we have installed, and run any cleanup
-        scripts that we have specified.
+        Run any cleanup scripts that we have specified and remove any
+        snaps that we have installed.
 
         '''
-
-        for step in self._base_setup + self._tests:
-            if not step.snap:
-                continue
-            subprocess.run(['sudo', 'snap', 'remove', step.snap])
 
         for step in self._test_cleanup:
             step.run(tempdir=self._tempdir)
 
         for step in self._base_cleanup:
             step.run(tempdir=self._tempdir)
+
+        for step in self._base_setup + self._tests:
+            if not step.snap:
+                continue
+            subprocess.run(['sudo', 'snap', 'remove', step.snap])
 
     def run(self, cleanup=True):
         '''

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -45,9 +45,13 @@ class TestPlan(unittest.TestCase):
             env=env)
 
         plan.run()  # Run plan again with cleanup
-        mock_subprocess.run.assert_called_with(
-            [os.sep.join([plan.tempdir, 'cleanup.py'])],
-            env=env)
+        scripts = ['keystone_cleanup.sh', 'nova_cleanup.sh',
+                   'neutron_cleanup.sh', 'glance_cleanup.sh',
+                   'nova-hypervisor_cleanup.sh']
+        for script in scripts:
+            mock_subprocess.run.assert_any_call(
+                [os.sep.join([plan.tempdir, script])],
+                env=env)
 
     @unittest.skipUnless(
         os.environ.get('SNAPSTACK_TEST_INSTALL'),


### PR DESCRIPTION
There are 2 commits here:

1) Extend the base Cleanup class to run cleanup scripts for
each of the base snaps.

2) Move the removal of snaps to be later in Plan.destroy(),
after cleanup scripts are run. Some of the cleanup scripts
(for example nova-hypervisor) run commands that are installed
by the snap.